### PR TITLE
Adds important declaration

### DIFF
--- a/src/Emotion.re
+++ b/src/Emotion.re
@@ -32,6 +32,12 @@ module Selector = {
 
 let p = (prop, value) => [(prop, value)]->Declaration.pack;
 
+let important = (v: declaration) =>
+  switch (v->Declaration.unpack) {
+  | [(prop, value)] => [(prop, value ++ " !important")]->Declaration.pack
+  | v => v->Declaration.pack
+  };
+
 let label = (x: string) => p("label", x);
 
 let display = x => p("display", x->Display.toString);


### PR DESCRIPTION
I was missing `important` working in the most hostile environment possible: Wordpress Plugins 😂 