### PR TITLE
Add Azure Pipelines and multiplatform builds

### DIFF
--- a/.ci/azure-pipelines.yml
+++ b/.ci/azure-pipelines.yml
@@ -1,4 +1,4 @@
-name: bs-emotion CI ${Build.BuildId}
+name: bs-emotion CI
 
 trigger:
   - refs/tags/master
@@ -9,6 +9,7 @@ jobs:
       name: "Windows_bs_emotion_ppx"
       vmImage: "vs2017-win2016"
       platform: "Windows"
+      fileEnding: ".exe"
 
   - template: bs-emotion-ppx/pipeline.yml # Template reference
     parameters:
@@ -21,6 +22,13 @@ jobs:
       name: "Linux_bs_emotion_ppx"
       vmImage: "ubuntu-16.04"
       platform: "Linux"
+
+  - job: Bundle_bs_emotion_ppx
+    pool:
+      vmImage: ubuntu-16.04
+
+    steps:
+      -tempalte: bs-emotion/bundle.yml
 
   - job: Linux_bs_emotion
     pool:

--- a/.ci/azure-pipelines.yml
+++ b/.ci/azure-pipelines.yml
@@ -6,23 +6,23 @@ trigger:
 jobs:
   - template: bs-emotion-ppx/pipeline.yml # Template reference
     parameters:
-      name: "Windows bs-emotion-ppx"
+      name: "Windows_bs_emotion_ppx"
       vmImage: "vs2017-win2016"
       platform: "Windows"
 
   - template: bs-emotion-ppx/pipeline.yml # Template reference
     parameters:
-      name: "macOS bs-emotion-ppx"
+      name: "macOS_bs_emotion_ppx"
       vmImage: "macOS-10.13"
       platform: "macOS"
 
   - template: bs-emotion-ppx/pipeline.yml # Template reference
     parameters:
-      name: "Linux bs-emotion-ppx"
+      name: "Linux_bs_emotion_ppx"
       vmImage: "ubuntu-16.04"
       platform: "Linux"
 
-  - job: Linux bs-emotion
+  - job: Linux_bs_emotion
     pool:
       vmImage: ubuntu-16.04
 

--- a/.ci/azure-pipelines.yml
+++ b/.ci/azure-pipelines.yml
@@ -26,14 +26,16 @@ jobs:
   - job: Bundle_bs_emotion_ppx
     pool:
       vmImage: ubuntu-16.04
-
+    dependsOn:
+      - Linux_bs_emotion_ppx
+      - macOS_bs_emotion_ppx
+      - Windows_bs_emotion_ppx
     steps:
       - template: bs-emotion-ppx/bundle.yml
 
   - job: Linux_bs_emotion
     pool:
       vmImage: ubuntu-16.04
-
     steps:
       - template: bs-emotion/install.yml
       - template: bs-emotion/build.yml

--- a/.ci/azure-pipelines.yml
+++ b/.ci/azure-pipelines.yml
@@ -1,0 +1,33 @@
+name: bs-emotion CI ${Build.BuildId}
+
+trigger:
+  - refs/tags/master
+
+jobs:
+  - template: bs-emotion-ppx/pipeline.yml # Template reference
+    parameters:
+      name: "Windows bs-emotion-ppx"
+      vmImage: "vs2017-win2016"
+      platform: "Windows"
+
+  - template: bs-emotion-ppx/pipeline.yml # Template reference
+    parameters:
+      name: "macOS bs-emotion-ppx"
+      vmImage: "macOS-10.13"
+      platform: "macOS"
+
+  - template: bs-emotion-ppx/pipeline.yml # Template reference
+    parameters:
+      name: "Linux bs-emotion-ppx"
+      vmImage: "ubuntu-16.04"
+      platform: "Linux"
+
+  - job: Linux bs-emotion
+    pool:
+      vmImage: ubuntu-16.04
+
+    steps:
+      - template: bs-emotion/install.yml
+      - template: bs-emotion/build.yml
+      - template: bs-emotion/test.yml
+      - template: bs-emotion/publish.yml

--- a/.ci/azure-pipelines.yml
+++ b/.ci/azure-pipelines.yml
@@ -28,7 +28,7 @@ jobs:
       vmImage: ubuntu-16.04
 
     steps:
-      -tempalte: bs-emotion/bundle.yml
+      - template: bs-emotion-ppx/bundle.yml
 
   - job: Linux_bs_emotion
     pool:

--- a/.ci/azure-pipelines.yml
+++ b/.ci/azure-pipelines.yml
@@ -32,12 +32,13 @@ jobs:
       - Windows_bs_emotion_ppx
     steps:
       - template: bs-emotion-ppx/bundle.yml
-
-  - job: Linux_bs_emotion
-    pool:
-      vmImage: ubuntu-16.04
-    steps:
-      - template: bs-emotion/install.yml
-      - template: bs-emotion/build.yml
-      - template: bs-emotion/test.yml
-      - template: bs-emotion/publish.yml
+  #
+  # Removed for now as we don't need to do anything fancy here
+  # - job: Linux_bs_emotion
+  #   pool:
+  #     vmImage: ubuntu-16.04
+  #   steps:
+  #     - template: bs-emotion/install.yml
+  #     - template: bs-emotion/build.yml
+  #     - template: bs-emotion/test.yml
+  #     - template: bs-emotion/publish.yml

--- a/.ci/bs-emotion-ppx/build.yml
+++ b/.ci/bs-emotion-ppx/build.yml
@@ -1,3 +1,4 @@
 steps:
   - script: npm run build
     workingDirectory: "bs-emotion-ppx"
+    displayName: "npm run build"

--- a/.ci/bs-emotion-ppx/build.yml
+++ b/.ci/bs-emotion-ppx/build.yml
@@ -1,3 +1,3 @@
 steps:
   - script: npm run build
-    workingDirectory: "${Build.SourcesDirectory}/bs-emotion-ppx"
+    workingDirectory: "bs-emotion-ppx"

--- a/.ci/bs-emotion-ppx/build.yml
+++ b/.ci/bs-emotion-ppx/build.yml
@@ -1,0 +1,3 @@
+steps:
+  - script: npm run build
+    workingDirectory: "${Build.SourcesDirectory}/bs-emotion-ppx"

--- a/.ci/bs-emotion-ppx/bundle.yml
+++ b/.ci/bs-emotion-ppx/bundle.yml
@@ -1,0 +1,56 @@
+steps:
+  - task: NodeTool@0
+    displayName: "Use Node 8.x"
+    inputs:
+      versionSpec: 8.x
+
+  - task: DownloadBuildArtifacts@0
+    displayName: "Download Linux Artifacts"
+    inputs:
+      artifactName: Linux
+      downloadPath: "_release"
+
+  - script: "mkdir _release/platform-linux"
+    displayName: "Create _release/platform-linux"
+
+  - script: "mv -r _release/Linux/ _release/platform-linux"
+    displayName: "mv Linux"
+
+  - task: DownloadBuildArtifacts@0
+    displayName: "Download macOS Artifacts"
+    inputs:
+      artifactName: macOS
+      downloadPath: "_release"
+
+  - script: "mkdir _release/platform-darwin"
+    displayName: "Create _release/platform-darwin"
+
+  - script: "mv -r _release/macOS/ _release/platform-darwin"
+    displayName: "mv macOS"
+
+  - task: DownloadBuildArtifacts@0
+    displayName: "Download macOS Artifacts"
+    inputs:
+      artifactName: Windows
+      downloadPath: "_release"
+
+  - script: "mkdir _release/platform-windows-x64"
+    displayName: "Create _release/platform-windows"
+
+  - script: "mv -r _release/Windows/ _release/platform-windows"
+    displayName: "mv Windows"
+
+  - script: |
+    cp .ci/bs-emotion-ppx/postinstall.js _release/postinstall.js
+    cp bs-emotion-ppx/package.json _release/package.json
+    cp bs-emotion-ppx/bsconfig.json _release/bsconfig.json
+
+  - script: "npm pack"
+    displayName: "npm pack"
+    workingDirectory: "_release"
+
+  - task: PublishBuildArtifacts@1
+    displayName: "Publish Artifact: Release"
+    inputs:
+      PathtoPublish: "_release/*.tgz"
+      ArtifactName: Release

--- a/.ci/bs-emotion-ppx/bundle.yml
+++ b/.ci/bs-emotion-ppx/bundle.yml
@@ -41,9 +41,9 @@ steps:
     displayName: "mv Windows"
 
   - script: |
-    cp .ci/bs-emotion-ppx/postinstall.js _release/postinstall.js
-    cp bs-emotion-ppx/package.json _release/package.json
-    cp bs-emotion-ppx/bsconfig.json _release/bsconfig.json
+      cp .ci/bs-emotion-ppx/postinstall.js _release/postinstall.js
+      cp bs-emotion-ppx/package.json _release/package.json
+      cp bs-emotion-ppx/bsconfig.json _release/bsconfig.json
 
   - script: "npm pack"
     displayName: "npm pack"

--- a/.ci/bs-emotion-ppx/bundle.yml
+++ b/.ci/bs-emotion-ppx/bundle.yml
@@ -13,7 +13,7 @@ steps:
   - script: "mkdir _release/platform-linux"
     displayName: "Create _release/platform-linux"
 
-  - script: "mv -r _release/Linux/emotionppx.native _release/platform-linux/emotionppx.native"
+  - script: "mv _release/Linux/emotionppx.native _release/platform-linux/emotionppx.native"
     displayName: "mv Linux"
 
   - task: DownloadBuildArtifacts@0
@@ -25,7 +25,7 @@ steps:
   - script: "mkdir _release/platform-darwin"
     displayName: "Create _release/platform-darwin"
 
-  - script: "mv -r _release/macOS/emotionppx.native _release/platform-darwin/emotionppx.native"
+  - script: "mv _release/macOS/emotionppx.native _release/platform-darwin/emotionppx.native"
     displayName: "mv macOS"
 
   - task: DownloadBuildArtifacts@0
@@ -37,7 +37,7 @@ steps:
   - script: "mkdir _release/platform-windows-x64"
     displayName: "Create _release/platform-windows"
 
-  - script: "mv -r _release/Windows/emotionppx.native.exe _release/platform-windows/emotionppx.native.exe"
+  - script: "mv _release/Windows/emotionppx.native.exe _release/platform-windows/emotionppx.native.exe"
     displayName: "mv Windows"
 
   - script: |

--- a/.ci/bs-emotion-ppx/bundle.yml
+++ b/.ci/bs-emotion-ppx/bundle.yml
@@ -29,15 +29,15 @@ steps:
     displayName: "mv macOS"
 
   - task: DownloadBuildArtifacts@0
-    displayName: "Download macOS Artifacts"
+    displayName: "Download Windows Artifacts"
     inputs:
       artifactName: Windows
       downloadPath: "_release"
 
   - script: "mkdir _release/platform-windows-x64"
-    displayName: "Create _release/platform-windows"
+    displayName: "Create _release/platform-windows-x64"
 
-  - script: "mv _release/Windows/emotionppx.native.exe _release/platform-windows/emotionppx.native.exe"
+  - script: "mv _release/Windows/emotionppx.native.exe _release/platform-windows-x64/emotionppx.native.exe"
     displayName: "mv Windows"
 
   - script: |

--- a/.ci/bs-emotion-ppx/bundle.yml
+++ b/.ci/bs-emotion-ppx/bundle.yml
@@ -53,5 +53,5 @@ steps:
   - task: PublishBuildArtifacts@1
     displayName: "Publish Artifact: Release"
     inputs:
-      PathtoPublish: "_release/*.tgz"
+      PathtoPublish: "_release"
       ArtifactName: Release

--- a/.ci/bs-emotion-ppx/bundle.yml
+++ b/.ci/bs-emotion-ppx/bundle.yml
@@ -13,7 +13,7 @@ steps:
   - script: "mkdir _release/platform-linux"
     displayName: "Create _release/platform-linux"
 
-  - script: "mv -r _release/Linux/ _release/platform-linux"
+  - script: "mv -r _release/Linux/emotionppx.native _release/platform-linux/emotionppx.native"
     displayName: "mv Linux"
 
   - task: DownloadBuildArtifacts@0
@@ -25,7 +25,7 @@ steps:
   - script: "mkdir _release/platform-darwin"
     displayName: "Create _release/platform-darwin"
 
-  - script: "mv -r _release/macOS/ _release/platform-darwin"
+  - script: "mv -r _release/macOS/emotionppx.native _release/platform-darwin/emotionppx.native"
     displayName: "mv macOS"
 
   - task: DownloadBuildArtifacts@0
@@ -37,7 +37,7 @@ steps:
   - script: "mkdir _release/platform-windows-x64"
     displayName: "Create _release/platform-windows"
 
-  - script: "mv -r _release/Windows/ _release/platform-windows"
+  - script: "mv -r _release/Windows/emotionppx.native.exe _release/platform-windows/emotionppx.native.exe"
     displayName: "mv Windows"
 
   - script: |

--- a/.ci/bs-emotion-ppx/bundle.yml
+++ b/.ci/bs-emotion-ppx/bundle.yml
@@ -44,6 +44,7 @@ steps:
       cp .ci/bs-emotion-ppx/postinstall.js _release/postinstall.js
       cp bs-emotion-ppx/package.json _release/package.json
       cp bs-emotion-ppx/bsconfig.json _release/bsconfig.json
+    displayName: "Copy needed files"
 
   - script: "npm pack"
     displayName: "npm pack"

--- a/.ci/bs-emotion-ppx/install.yml
+++ b/.ci/bs-emotion-ppx/install.yml
@@ -6,3 +6,4 @@ steps:
 
   - script: npm install
     workingDirectory: "bs-emotion-ppx"
+    displayName: "npm install"

--- a/.ci/bs-emotion-ppx/install.yml
+++ b/.ci/bs-emotion-ppx/install.yml
@@ -1,3 +1,8 @@
 steps:
+  - task: NodeTool@0
+    displayName: "Use Node 8.x"
+    inputs:
+      versionSpec: 8.x
+
   - script: npm install
     workingDirectory: "bs-emotion-ppx"

--- a/.ci/bs-emotion-ppx/install.yml
+++ b/.ci/bs-emotion-ppx/install.yml
@@ -1,3 +1,3 @@
 steps:
   - script: npm install
-    workingDirectory: "${Build.SourcesDirectory}/bs-emotion-ppx"
+    workingDirectory: "bs-emotion-ppx"

--- a/.ci/bs-emotion-ppx/install.yml
+++ b/.ci/bs-emotion-ppx/install.yml
@@ -1,0 +1,3 @@
+steps:
+  - script: npm install
+    workingDirectory: "${Build.SourcesDirectory}/bs-emotion-ppx"

--- a/.ci/bs-emotion-ppx/pipeline.yml
+++ b/.ci/bs-emotion-ppx/pipeline.yml
@@ -1,0 +1,12 @@
+- job: ${{ parameters.name }}
+    pool:
+      vmImage: ${{ parameters.vmImage }}
+      demands: npm
+
+    steps:
+      - template: bs-emotion-ppx/install.yml
+      - template: bs-emotion-ppx/build.yml
+      - template: bs-emotion-ppx/test.yml
+      - template: bs-emotion-ppx/publish.yml
+        parameters:
+          platform: ${{ parameters.platform }}

--- a/.ci/bs-emotion-ppx/pipeline.yml
+++ b/.ci/bs-emotion-ppx/pipeline.yml
@@ -1,5 +1,5 @@
 parameters:
-  name: "macOS bs-emotion-ppx"
+  name: "macOS_bs_emotion_ppx"
   vmImage: "macOS-10.13"
   platform: "macOS"
 

--- a/.ci/bs-emotion-ppx/pipeline.yml
+++ b/.ci/bs-emotion-ppx/pipeline.yml
@@ -10,9 +10,9 @@ jobs:
       demands: npm
 
     steps:
-      - template: bs-emotion-ppx/install.yml
-      - template: bs-emotion-ppx/build.yml
-      - template: bs-emotion-ppx/test.yml
-      - template: bs-emotion-ppx/publish.yml
+      - template: install.yml
+      - template: build.yml
+      - template: test.yml
+      - template: publish.yml
         parameters:
           platform: ${{ parameters.platform }}

--- a/.ci/bs-emotion-ppx/pipeline.yml
+++ b/.ci/bs-emotion-ppx/pipeline.yml
@@ -1,4 +1,10 @@
-- job: ${{ parameters.name }}
+parameters:
+  name: "macOS bs-emotion-ppx"
+  vmImage: "macOS-10.13"
+  platform: "macOS"
+
+jobs:
+  - job: ${{ parameters.name }}
     pool:
       vmImage: ${{ parameters.vmImage }}
       demands: npm

--- a/.ci/bs-emotion-ppx/pipeline.yml
+++ b/.ci/bs-emotion-ppx/pipeline.yml
@@ -2,6 +2,7 @@ parameters:
   name: "macOS_bs_emotion_ppx"
   vmImage: "macOS-10.13"
   platform: "macOS"
+  fileEnding: ""
 
 jobs:
   - job: ${{ parameters.name }}
@@ -16,3 +17,4 @@ jobs:
       - template: publish.yml
         parameters:
           platform: ${{ parameters.platform }}
+          fileEnding: ${{ parameters.fileEnding }}

--- a/.ci/bs-emotion-ppx/postinstall.js
+++ b/.ci/bs-emotion-ppx/postinstall.js
@@ -1,0 +1,164 @@
+/**
+ * release-postinstall.js
+ *
+ * XXX: We want to keep this script installable at least with node 4.x.
+ *
+ * This script is bundled with the `npm` package and executed on release.
+ * Since we have a 'fat' NPM package (with all platform binaries bundled),
+ * this postinstall script extracts them and puts the current platform's
+ * bits in the right place.
+ */
+
+var path = require("path");
+var cp = require("child_process");
+var fs = require("fs");
+var os = require("os");
+var platform = process.platform;
+
+var binariesToCopy = [path.join("emotionppx.native")];
+var foldersToCopy = [];
+
+function copyRecursive(srcDir, dstDir) {
+  var results = [];
+  var list = fs.readdirSync(srcDir);
+  var src, dst;
+  list.forEach(function(file) {
+    src = path.join(srcDir, file);
+    dst = path.join(dstDir, file);
+
+    var stat = fs.statSync(src);
+    if (stat && stat.isDirectory()) {
+      try {
+        fs.mkdirSync(dst);
+      } catch (e) {
+        console.log("directory already exists: " + dst);
+        console.error(e);
+      }
+      results = results.concat(copyRecursive(src, dst));
+    } else {
+      try {
+        fs.writeFileSync(dst, fs.readFileSync(src));
+      } catch (e) {
+        console.log("could't copy file: " + dst);
+        console.error(e);
+      }
+      results.push(src);
+    }
+  });
+  return results;
+}
+
+/**
+ * Since os.arch returns node binary's target arch, not
+ * the system arch.
+ * Credits: https://github.com/feross/arch/blob/af080ff61346315559451715c5393d8e86a6d33c/index.js#L10-L58
+ */
+
+function arch() {
+  /**
+   * The running binary is 64-bit, so the OS is clearly 64-bit.
+   */
+  if (process.arch === "x64") {
+    return "x64";
+  }
+
+  /**
+   * All recent versions of Mac OS are 64-bit.
+   */
+  if (process.platform === "darwin") {
+    return "x64";
+  }
+
+  /**
+   * On Windows, the most reliable way to detect a 64-bit OS from within a 32-bit
+   * app is based on the presence of a WOW64 file: %SystemRoot%\SysNative.
+   * See: https://twitter.com/feross/status/776949077208510464
+   */
+  if (process.platform === "win32") {
+    var useEnv = false;
+    try {
+      useEnv = !!(
+        process.env.SYSTEMROOT && fs.statSync(process.env.SYSTEMROOT)
+      );
+    } catch (err) {}
+
+    var sysRoot = useEnv ? process.env.SYSTEMROOT : "C:\\Windows";
+
+    // If %SystemRoot%\SysNative exists, we are in a WOW64 FS Redirected application.
+    var isWOW64 = false;
+    try {
+      isWOW64 = !!fs.statSync(path.join(sysRoot, "sysnative"));
+    } catch (err) {}
+
+    return isWOW64 ? "x64" : "x86";
+  }
+
+  /**
+   * On Linux, use the `getconf` command to get the architecture.
+   */
+  if (process.platform === "linux") {
+    var output = cp.execSync("getconf LONG_BIT", { encoding: "utf8" });
+    return output === "64\n" ? "x64" : "x86";
+  }
+
+  /**
+   * If none of the above, assume the architecture is 32-bit.
+   */
+  return "x86";
+}
+
+// implementing it b/c we don't want to depend on fs.copyFileSync which appears
+// only in node@8.x
+function copyFileSync(sourcePath, destPath) {
+  var data = fs.readFileSync(sourcePath);
+  var stat = fs.statSync(sourcePath);
+  fs.writeFileSync(destPath, data);
+  fs.chmodSync(destPath, stat.mode);
+}
+
+var copyPlatformBinaries = platformPath => {
+  var platformBuildPath = path.join(__dirname, "platform-" + platformPath);
+
+  foldersToCopy.forEach(folderPath => {
+    var sourcePath = path.join(platformBuildPath, folderPath);
+    var destPath = path.join(__dirname, folderPath);
+
+    copyRecursive(sourcePath, destPath);
+  });
+
+  binariesToCopy.forEach(binaryPath => {
+    var sourcePath = path.join(platformBuildPath, binaryPath);
+    var destPath = path.join(__dirname, binaryPath);
+    if (fs.existsSync(destPath)) {
+      fs.unlinkSync(destPath);
+    }
+    copyFileSync(sourcePath, destPath);
+    fs.chmodSync(destPath, 0777);
+  });
+};
+
+try {
+  fs.mkdirSync("_export");
+} catch (e) {
+  console.log("Could not create _export folder");
+}
+
+switch (platform) {
+  case "win32":
+    if (arch() !== "x64") {
+      console.warn("error: x86 is currently not supported on Windows");
+      process.exit(1);
+    }
+
+    copyPlatformBinaries("windows-x64");
+    break;
+  case "linux":
+  case "darwin":
+    copyPlatformBinaries(platform);
+    break;
+  default:
+    console.warn("error: no release built for the " + platform + " platform");
+    process.exit(1);
+}
+
+require("./esyInstallRelease");

--- a/.ci/bs-emotion-ppx/publish.yml
+++ b/.ci/bs-emotion-ppx/publish.yml
@@ -1,0 +1,8 @@
+steps:
+  - task: PublishBuildArtifacts@1
+    displayName: "Publish ${{ parameters.platform }}"
+    inputs:
+      pathToPublish: "$(Build.SourcesDirectory)/bs-emotion-ppx/lib/bs/native"
+      artifactName: "${{ parameters.platform }}-ppx"
+      parallel: true
+      parallelCount: 8

--- a/.ci/bs-emotion-ppx/publish.yml
+++ b/.ci/bs-emotion-ppx/publish.yml
@@ -2,7 +2,7 @@ steps:
   - task: PublishBuildArtifacts@1
     displayName: "Publish ${{ parameters.platform }}"
     inputs:
-      pathToPublish: "$(Build.SourcesDirectory)/bs-emotion-ppx/lib/bs/native"
+      pathToPublish: "bs-emotion-ppx/lib/bs/native"
       artifactName: "${{ parameters.platform }}-ppx"
       parallel: true
       parallelCount: 8

--- a/.ci/bs-emotion-ppx/publish.yml
+++ b/.ci/bs-emotion-ppx/publish.yml
@@ -2,7 +2,7 @@ steps:
   - task: PublishBuildArtifacts@1
     displayName: "Publish ${{ parameters.platform }}"
     inputs:
-      pathToPublish: "bs-emotion-ppx/lib/bs/native"
+      pathToPublish: "bs-emotion-ppx/lib/bs/native/emotionppx.native"
       artifactName: "${{ parameters.platform }}-ppx"
       parallel: true
       parallelCount: 8

--- a/.ci/bs-emotion-ppx/publish.yml
+++ b/.ci/bs-emotion-ppx/publish.yml
@@ -2,7 +2,7 @@ steps:
   - task: PublishBuildArtifacts@1
     displayName: "Publish ${{ parameters.platform }}"
     inputs:
-      pathToPublish: "bs-emotion-ppx/lib/bs/native/emotionppx.native"
-      artifactName: "${{ parameters.platform }}-ppx"
+      pathToPublish: "bs-emotion-ppx/lib/bs/native/emotionppx.native${{ parameters.fileEnding }}"
+      artifactName: "${{ parameters.platform }}"
       parallel: true
       parallelCount: 8

--- a/.ci/bs-emotion-ppx/test.yml
+++ b/.ci/bs-emotion-ppx/test.yml
@@ -1,3 +1,4 @@
 steps:
   - script: npm run test
     workingDirectory: "bs-emotion-ppx"
+    displayName: "npm run test"

--- a/.ci/bs-emotion-ppx/test.yml
+++ b/.ci/bs-emotion-ppx/test.yml
@@ -1,3 +1,3 @@
 steps:
   - script: npm run test
-    workingDirectory: "${Build.SourcesDirectory}/bs-emotion-ppx"
+    workingDirectory: "bs-emotion-ppx"

--- a/.ci/bs-emotion-ppx/test.yml
+++ b/.ci/bs-emotion-ppx/test.yml
@@ -1,0 +1,3 @@
+steps:
+  - script: npm run test
+    workingDirectory: "${Build.SourcesDirectory}/bs-emotion-ppx"

--- a/.ci/bs-emotion/build.yml
+++ b/.ci/bs-emotion/build.yml
@@ -1,0 +1,3 @@
+steps:
+  - script: npm run build
+    workingDirectory: "${Build.SourcesDirectory}/bs-emotion"

--- a/.ci/bs-emotion/build.yml
+++ b/.ci/bs-emotion/build.yml
@@ -1,3 +1,4 @@
 steps:
   - script: npm run build
     workingDirectory: "bs-emotion"
+    displayName: "npm run build"

--- a/.ci/bs-emotion/build.yml
+++ b/.ci/bs-emotion/build.yml
@@ -1,3 +1,3 @@
 steps:
   - script: npm run build
-    workingDirectory: "${Build.SourcesDirectory}/bs-emotion"
+    workingDirectory: "bs-emotion"

--- a/.ci/bs-emotion/install.yml
+++ b/.ci/bs-emotion/install.yml
@@ -1,3 +1,8 @@
 steps:
+  - task: NodeTool@0
+    displayName: "Use Node 8.x"
+    inputs:
+      versionSpec: 8.x
+
   - script: npm install
     workingDirectory: "bs-emotion"

--- a/.ci/bs-emotion/install.yml
+++ b/.ci/bs-emotion/install.yml
@@ -1,3 +1,3 @@
 steps:
   - script: npm install
-    workingDirectory: "${Build.SourcesDirectory}/bs-emotion"
+    workingDirectory: "bs-emotion"

--- a/.ci/bs-emotion/install.yml
+++ b/.ci/bs-emotion/install.yml
@@ -6,3 +6,4 @@ steps:
 
   - script: npm install
     workingDirectory: "bs-emotion"
+    displayName: "npm install"

--- a/.ci/bs-emotion/install.yml
+++ b/.ci/bs-emotion/install.yml
@@ -1,0 +1,3 @@
+steps:
+  - script: npm install
+    workingDirectory: "${Build.SourcesDirectory}/bs-emotion"

--- a/.ci/bs-emotion/publish.yml
+++ b/.ci/bs-emotion/publish.yml
@@ -2,7 +2,7 @@ steps:
   - task: PublishBuildArtifacts@1
     displayName: "Publish ${{ parameters.platform }}"
     inputs:
-      pathToPublish: "$(Build.SourcesDirectory)/bs-emotion"
+      pathToPublish: "bs-emotion"
       artifactName: "${{ parameters.platform }}-ppx"
       parallel: true
       parallelCount: 8

--- a/.ci/bs-emotion/publish.yml
+++ b/.ci/bs-emotion/publish.yml
@@ -1,5 +1,6 @@
 steps:
   - script: rm -rf node_modules
+    workingDirectory: "bs-emotion"
     displayName: "Remove node_modules"
 
   - task: PublishBuildArtifacts@1

--- a/.ci/bs-emotion/publish.yml
+++ b/.ci/bs-emotion/publish.yml
@@ -1,4 +1,7 @@
 steps:
+  - script: rm -rf node_modules
+    displayName: "Remove node_modules"
+
   - task: PublishBuildArtifacts@1
     displayName: "Publish ${{ parameters.platform }}"
     inputs:

--- a/.ci/bs-emotion/publish.yml
+++ b/.ci/bs-emotion/publish.yml
@@ -1,0 +1,8 @@
+steps:
+  - task: PublishBuildArtifacts@1
+    displayName: "Publish ${{ parameters.platform }}"
+    inputs:
+      pathToPublish: "$(Build.SourcesDirectory)/bs-emotion"
+      artifactName: "${{ parameters.platform }}-ppx"
+      parallel: true
+      parallelCount: 8

--- a/.ci/bs-emotion/publish.yml
+++ b/.ci/bs-emotion/publish.yml
@@ -1,12 +1,12 @@
 steps:
-  - script: rm -rf node_modules
+  - script: npm pack
     workingDirectory: "bs-emotion"
-    displayName: "Remove node_modules"
+    displayName: "npm pack"
 
   - task: PublishBuildArtifacts@1
-    displayName: "Publish ${{ parameters.platform }}"
+    displayName: "Publish bs-emotion"
     inputs:
-      pathToPublish: "bs-emotion"
-      artifactName: "${{ parameters.platform }}-ppx"
+      pathToPublish: "bs-emotion/bs-emotion*.tgz"
+      artifactName: "bs-emotion"
       parallel: true
       parallelCount: 8

--- a/.ci/bs-emotion/test.yml
+++ b/.ci/bs-emotion/test.yml
@@ -1,3 +1,3 @@
 steps:
   - script: npm run test
-    workingDirectory: "${Build.SourcesDirectory}/bs-emotion"
+    workingDirectory: "bs-emotion"

--- a/.ci/bs-emotion/test.yml
+++ b/.ci/bs-emotion/test.yml
@@ -1,0 +1,3 @@
+steps:
+  - script: npm run test
+    workingDirectory: "${Build.SourcesDirectory}/bs-emotion"

--- a/.ci/bs-emotion/test.yml
+++ b/.ci/bs-emotion/test.yml
@@ -1,3 +1,4 @@
 steps:
   - script: npm run test
     workingDirectory: "bs-emotion"
+    displayName: "npm test"

--- a/bs-emotion-ppx/package.json
+++ b/bs-emotion-ppx/package.json
@@ -16,8 +16,8 @@
     "postinstall": "bsb -make-world -backend native && cp lib/bs/native/emotionppx.native ppx"
   },
   "files": [
-    "src",
-    "test",
+    "platform-*",
+    "postinstall.js",
     "bsconfig.json"
   ],
   "dependencies": {

--- a/bs-emotion-ppx/package.json
+++ b/bs-emotion-ppx/package.json
@@ -20,7 +20,7 @@
     "postinstall.js",
     "bsconfig.json"
   ],
-  "dependencies": {
+  "devDependencies": {
     "bsb-native": "4.0.7000"
   },
   "keywords": [


### PR DESCRIPTION
This PR adds Azure Pipelines and with it a way to easily publish binaries for every platform in 1 package. This removes the dependency on bsb-native at install time, the drawback as that we download ppxes for every platform on each install, but it should be lighter anyway.

**What the pipeline does:**

In 1 agent for each platform, Windows, Linux and macOS

1. Clone the repo
2. `npm install`
3. `npm run build`
4. `npm run test`
5. publish the ppx

When the 3 platforms have finished start a Linux agent

1. Clone the repo
2. download the ppxes from all platforms
3. move them to a folder for each platform
4. copy package.json, bsconfig.json and a postinstall.js
5. run  `npm pack` in the _release folder
6. publish the _release folder
7. That package created from `npm pack` can then be published to npm as is

When the user installs the package the `postinstall.js` will figure out what platform it's on and copy the correct ppx. I probably need help to make the `postinstall.js` script correct.

I can rebase some commits to the essential commits as there were a lot of trials to get this working correctly or you can just squash it.